### PR TITLE
Update for PrusaSlicer 2.8

### DIFF
--- a/Kingroon.idx
+++ b/Kingroon.idx
@@ -1,4 +1,5 @@
 min_slic3r_version = 2.6.0-alpha0
+1.5.0 Update for PrusaSlicer 2.8
 1.4.0 Added new build plate textures and renamed "Kingroon KP3SProS1" profiles
 1.3.1 Adjusted min/max layer heights for nozzles
 1.3.0 Added support for KP3S Pro S1

--- a/Kingroon.ini
+++ b/Kingroon.ini
@@ -6,7 +6,8 @@ repo_id = non-prusa-fff
 name = Kingroon
 # Configuration version of this file. Config file will only be installed, if the config_version differs.
 # This means, the server may force the PrusaSlicer configuration to be downgraded.
-config_version = 1.4.0
+config_version = 1.5.0
+repo_id = non-prusa-fff
 # Where to get the updates from?
 # config_update_url = nourl
 # changelog_url = nourl


### PR DESCRIPTION
From version 2.8 PrusaSlicer requires setting additional parameter in vendor section.https://github.com/prusa3d/PrusaSlicer/wiki/Vendor-bundles-and-updating-process#:~:text=repo_id%20%3D%20non%2Dprusa%2Dfff